### PR TITLE
Update Schedule for DayCamp 2018

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 OSUOSL DevOpsBootcamp
-Copyright (C) 2014 - 2017 Oregon State University
+Copyright (C) 2014 - 2018 Oregon State University
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/devopstheme/templates/index.html
+++ b/devopstheme/templates/index.html
@@ -8,8 +8,8 @@
         <img src='{{ SITEURL }}/theme/img/cloud.png' class='cloud2'>
     </div>
     <div class='text'>
-        <h1>Devops BootCamp Fall Kickoff</h1>
-        <h2>November 4th, 2017<br>
+        <h1>Devops DayCamp</h1>
+        <h2>May 12th, 2018<br>
             Kelley Engineering Center<br>
             1001 & 1003</h2>
         <a href="https://devopsbootcamp-fall-kickoff.eventbrite.com" class='button' id='register'>Register</a>


### PR DESCRIPTION
This is in a preliminary state right now, there are still some changes to make. Part of this [Trello card](https://trello.com/c/kQXsLiLl/691-daycamp).

Here's a list of what I think needs to be done, please let me know if anything is missing:

- [ ] Update the eventbrite link for registation.
- [ ] Update 'about' section with relevant information.
- [ ] Update 'schedule' section to better reflect the sessions.
- [ ] Remove industry panel section(?)